### PR TITLE
Feat fix token size

### DIFF
--- a/templates/etc/supervisor.d/ecr.ini
+++ b/templates/etc/supervisor.d/ecr.ini
@@ -1,4 +1,5 @@
 [supervisord]
+user = root
 nodaemon=true
 
 [program:nginx]
@@ -14,3 +15,5 @@ autostart = true
 user = root
 command = crond -f
 autostart = true
+stderr_logfile=/dev/stderr
+stdout_logfile=/dev/stdout

--- a/templates/etc/supervisor.d/ecr.ini
+++ b/templates/etc/supervisor.d/ecr.ini
@@ -17,3 +17,5 @@ command = crond -f
 autostart = true
 stderr_logfile=/dev/stderr
 stdout_logfile=/dev/stdout
+stderr_logfile_maxbytes=0
+stdout_logfile_maxbytes=0

--- a/templates/scripts/renew-token.sh
+++ b/templates/scripts/renew-token.sh
@@ -10,6 +10,7 @@ while true; do
   NEW_TOKEN=$(aws ecr get-login --no-include-email | awk '{ print $6 }')
   if [ ! -z "${ESC}{NEW_TOKEN}" ]; then
     break
+    echo "Success: Got token"
   fi
   echo "Warning: unable to get new token, waiting before retry..."
   sleep 30
@@ -24,4 +25,6 @@ sed -i "s|${ESC}{EXISTING_TOKEN%??}|${ESC}{NEW_TOKEN}|g" $NGINX_CONFIG_DIR/nginx
 # reload the nginx service if it was runnign
 if test -f $NGINX_DIR/logs/nginx.pid; then
   nginx -s reload
+  echo "Success: nginx reloaded."
 fi
+echo "Done"

--- a/templates/usr/local/openresty/nginx/conf/nginx.conf
+++ b/templates/usr/local/openresty/nginx/conf/nginx.conf
@@ -41,7 +41,7 @@ http {
     listen $PROXY_$PROXY_PORT $PROXY_LISTENER_OPTIONS default_server;
 
     set_by_lua_block ${ESC}auth_headers {
-        local f = io.open("/usr/local/openresty/nginx/conf/token")
+        local f = io.open("$NGINX_CONFIG_DIR/token")
         if not f then
             ngx.log(ngx.ERR, "failed to open token file")
             return nil

--- a/templates/usr/local/openresty/nginx/conf/nginx.conf
+++ b/templates/usr/local/openresty/nginx/conf/nginx.conf
@@ -1,5 +1,7 @@
 user  nginx;
 worker_processes  1;
+# # Debugging
+# error_log /dev/stderr debug;
 
 events {
     worker_connections  1024;
@@ -12,6 +14,10 @@ http {
   keepalive_timeout 65;
   sendfile on;
 
+  large_client_header_buffers 4 32k;
+  proxy_buffer_size 32k;
+  proxy_buffers 4 32k;
+
   proxy_cache_path /cache/cache levels=1:2 keys_zone=cache:16m inactive=1y max_size=$PROXY_CACHE_LIMIT use_temp_path=off;
   resolver $PROXY_DNS_RESOLVER valid=30s;
 
@@ -21,6 +27,11 @@ http {
   # will run before forking out nginx worker processes
   init_by_lua_block { require "cjson" }
 
+  log_format proxy '${ESC}remote_addr - ${ESC}upstream_cache_status [${ESC}time_local] "${ESC}request" '
+                      '${ESC}status ${ESC}body_bytes_sent "${ESC}http_referer" '
+                      '"${ESC}http_user_agent" "${ESC}http_x_forwarded_for" '
+                      'rt=${ESC}request_time uct="${ESC}upstream_connect_time" uht="${ESC}upstream_header_time" urt="${ESC}upstream_response_time"';
+
   #https://docs.docker.com/registry/recipes/nginx/#setting-things-up
   map ${ESC}upstream_http_docker_distribution_api_version ${ESC}docker_distribution_api_version {
   '' 'registry/2.0';
@@ -28,6 +39,22 @@ http {
 
   server {
     listen $PROXY_$PROXY_PORT $PROXY_LISTENER_OPTIONS default_server;
+
+    set_by_lua_block ${ESC}auth_headers {
+        local f = io.open("/usr/local/openresty/nginx/conf/token")
+        if not f then
+            ngx.log(ngx.ERR, "failed to open token file")
+            return nil
+        end
+        local c = f:read("*all")
+        f:close()
+        if not c then
+            ngx.log(ngx.ERR, "failed to read token file")
+            return nil
+        end
+        return c
+    }
+    
 
     $PROXY_LISTENER_INCLUDES
 
@@ -59,13 +86,18 @@ http {
       return 401;
     }
 
-    # health check
+    # health check no logging
     location /health {
+      access_log off;
+      error_log /dev/stderr error;
       return 200;
     }
 
     # Pass through enabled repositories.
     location ~ ^/v2/$PROXY_NAMESPACE_PATTERN.*  {
+
+      access_log /dev/stdout proxy;
+
       set ${ESC}url        $PROXY_ECR_ENDPOINT;
       proxy_pass      ${ESC}url;
       proxy_redirect  ${ESC}url $PROXY_LISTENER_SCHEME://${ESC}host:$PROXY_PORT;
@@ -73,14 +105,17 @@ http {
       # Add AWS ECR authentication headers
       proxy_set_header  X-Real-IP          ${ESC}remote_addr;
       proxy_set_header  X-Forwarded-For    ${ESC}remote_addr;
-      proxy_set_header  X-Forwarded-User   "Basic ${ESC}http_authorization";
-      proxy_set_header  Authorization      "Basic ${ESC}http_authorization";
+      proxy_set_header  X-Forwarded-User   ${ESC}auth_headers;
+      proxy_set_header  Authorization      ${ESC}auth_headers;
       proxy_set_header  X-Forwarded-Proto  ${ESC}scheme;
     }
 
     # Content addressable files like blobs.
     # https://docs.docker.com/registry/spec/api/#blob
     location ~ ^/v2/.*/blobs/[a-z0-9]+:[a-f0-9]+$ {
+
+      access_log /dev/stdout proxy;
+
       set ${ESC}url        $PROXY_ECR_ENDPOINT;
       proxy_pass      ${ESC}url;
       proxy_redirect  ${ESC}url $PROXY_LISTENER_SCHEME://${ESC}host:$PROXY_PORT;
@@ -88,8 +123,8 @@ http {
       # Add AWS ECR authentication headers
       proxy_set_header  X-Real-IP          ${ESC}remote_addr;
       proxy_set_header  X-Forwarded-For    ${ESC}remote_addr;
-      proxy_set_header  X-Forwarded-User   "Basic ${ESC}http_authorization";
-      proxy_set_header  Authorization      "Basic ${ESC}http_authorization";
+      proxy_set_header  X-Forwarded-User   ${ESC}auth_headers;
+      proxy_set_header  Authorization      ${ESC}auth_headers;
       proxy_set_header  X-Forwarded-Proto  ${ESC}scheme;
 
       # When accessing image blobs using HTTP GET AWS ECR redirects with
@@ -103,6 +138,9 @@ http {
     # query params. Also the params should be part of cache key for nginx to
     # issue HIT for same image blob.
     location @handle_redirect {
+
+      access_log /dev/stdout proxy;
+
       set                    ${ESC}saved_redirect_location '${ESC}upstream_http_location';
       proxy_pass             ${ESC}saved_redirect_location;
       proxy_cache            cache;
@@ -145,6 +183,9 @@ http {
     # Helper location for getting tags from upstream repository
     # used for getting paginated tags.
     location /get_tags {
+
+      access_log /dev/stdout proxy;
+
       internal;
       set_unescape_uri      ${ESC}req_uri ${ESC}arg_req_uri;
       proxy_pass            $PROXY_ECR_ENDPOINT${ESC}req_uri;
@@ -152,8 +193,8 @@ http {
       # Add AWS ECR authentication headers
       proxy_set_header  X-Real-IP          ${ESC}remote_addr;
       proxy_set_header  X-Forwarded-For    ${ESC}remote_addr;
-      proxy_set_header  X-Forwarded-User   "Basic ${ESC}http_authorization";
-      proxy_set_header  Authorization      "Basic ${ESC}http_authorization";
+      proxy_set_header  X-Forwarded-User   ${ESC}auth_headers;
+      proxy_set_header  Authorization      ${ESC}auth_headers;
       proxy_set_header  X-Forwarded-Proto  ${ESC}scheme;
     }
   }


### PR DESCRIPTION
Related to [ECR token pushes the line over 4096. Which is unresolvable without rebuilding NGINX](https://github.com/whitfin/aws-ecr-proxy/issues/1)

### Fixes 
- misspelling in comment
- token size issue causing nginx crash
- adds some additional logging
- resolves annoying supervisord error for stdout and root ownership
- adds region to AWS token pull
- changed log formatting