### PR TITLE
Trim trailing whitespace from ECR auth token

### DIFF
--- a/templates/usr/local/openresty/nginx/conf/http/tokens.conf
+++ b/templates/usr/local/openresty/nginx/conf/http/tokens.conf
@@ -15,6 +15,7 @@ init_worker_by_lua_block {
 
   -- Schedule the ECR token rotation into the shared storage
   ngx_aws_token.rotate("ecr", ngx_aws_command, function (token)
+    token = string.gsub(token, "%s+$", "")
     return "Basic " .. token
   end)
 }


### PR DESCRIPTION
## Why

This change trims trailing whitespace from the ECR authorization token before sending it in the Authorization header.

In local testing, the proxy could authenticate successfully against ECR, but manifest requests by tag could still return schema v1 instead of schema v2. Trimming trailing whitespace from the token fixed that behavior.

Most likely, the AWS CLI output included a trailing newline, and that newline was being forwarded inside the Authorization header value.

## Reproduction

Before the change, the same image could return different manifest schemas through the proxy:

```sh
curl -skI http://localhost:5000/v2/example/image/manifests/latest
curl -skI http://localhost:5000/v2/example/image/manifests/sha256:<digest>
```

Observed behavior before the fix:
- tag request returned `Content-Type: application/vnd.docker.distribution.manifest.v1+prettyjws`
- digest request returned `Content-Type: application/vnd.docker.distribution.manifest.v2+json`

After trimming the token, the tag request also returned schema v2.

## Change

```lua
token = string.gsub(token, "%s+$", "")
```

## Verification

Verified locally against an ECR-backed proxy setup.

## Note

This PR was prepared with the help of Codex and verified locally by a human.
